### PR TITLE
Unify graph and table data via shared context

### DIFF
--- a/packages/ui/src/hooks/useTableData.ts
+++ b/packages/ui/src/hooks/useTableData.ts
@@ -1,19 +1,49 @@
 /** @format */
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, createContext, useContext } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { AllGroupResponses, AllInstanceResponses, useResourceHooks, type ResourceKey } from "./useApiTyped";
 import { components } from "@/types/api";
 import { queryClient } from "./useApi";
 
 type IndexType = components["schemas"]["IndexType"];
+type GraphDataResponse = components["schemas"]["GraphDataResponse"];
 
 type Props = {
   key: ResourceKey;
   defaultInstanceStatusType: string;
 };
 
-export const useTableData =<TInstance extends AllInstanceResponses, TGroup extends AllGroupResponses> ({ key, defaultInstanceStatusType }: Props) => {
+export type TableDataResult = {
+  instanceData: AllInstanceResponses[];
+  groupData: AllGroupResponses[];
+  instanceDataCount: string;
+  groupDataCount: string;
+  index: IndexType;
+  instanceStatusType: string;
+  inputValue: string;
+  message: string;
+  modelKey: string;
+  loading: boolean;
+  isFetchingMore: boolean;
+  hasNextPage: boolean;
+  graphData: GraphDataResponse | undefined;
+  graphLoading: boolean;
+  loadMore: () => void;
+  setInputValue: (val: string) => void;
+  setInstanceStatusType: (val: string) => void;
+  setIndex: (val: IndexType) => void;
+};
+
+export const TableDataContext = createContext<TableDataResult | null>(null);
+
+export const useTableDataContext = (): TableDataResult => {
+  const ctx = useContext(TableDataContext);
+  if (!ctx) throw new Error("useTableDataContext must be used within a TableDataProvider");
+  return ctx;
+};
+
+export const useTableData = <TInstance extends AllInstanceResponses, TGroup extends AllGroupResponses>({ key, defaultInstanceStatusType }: Props): TableDataResult => {
   const modelKey = useParams<{ key: string }>().key || "";
   const resourceHooks = useResourceHooks(key);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -80,6 +110,12 @@ export const useTableData =<TInstance extends AllInstanceResponses, TGroup exten
     { enabled: index === "group" },
   );
 
+  const graphQuery = resourceHooks.useGraph({
+    q: inputValue || undefined,
+    key: modelKey || undefined,
+    status: instanceStatusType?.toLowerCase(),
+  });
+
   const instanceData = useMemo(() =>
       //@ts-ignore
       (instanceQuery.data?.pages ?? []).flatMap((page) => page.results),
@@ -117,6 +153,8 @@ export const useTableData =<TInstance extends AllInstanceResponses, TGroup exten
     loading: activeQuery.isLoading,
     isFetchingMore: activeQuery.isFetchingNextPage,
     hasNextPage: activeQuery.hasNextPage,
+    graphData: graphQuery.data,
+    graphLoading: graphQuery.isLoading,
     loadMore: activeQuery.fetchNextPage,
     setInputValue,
     setInstanceStatusType,

--- a/packages/ui/src/screens/cache/index/index.tsx
+++ b/packages/ui/src/screens/cache/index/index.tsx
@@ -6,7 +6,7 @@ import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsCard } from "@/components/ui/cards/stats-card";
 import { DurationCard } from "@/components/ui/cards/duration-card";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useCaches } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const CACHE_BAR_DATA = [
   { dataKey: "hits", stackId: "a", fill: "#f1f5f9" },
@@ -15,37 +15,40 @@ const CACHE_BAR_DATA = [
 ];
 
 export default function CacheIndex() {
-  const { isLoading, data } = useCaches.useGraph({});
-
-   if (isLoading || !data) return null;
+  const tableData = useTableData({ key: "cache", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <IndexLayout>
-      <StatsGrid columns={2}>
-        <StatsCard
-          title="TRANSACTIONS"
-          count={data.count}
-          badges={[
-            { label: "HITS", value: data.indexCountOne, variant: "secondary" },
-            { label: "WRITES", value: data.indexCountTwo, variant: "warning" },
-            { label: "MISSES", value: data.indexCountThree, variant: "error" },
-          ]}
-          graph={
-            <CountGraph
-              data={data.countFormattedData}
-              barData={CACHE_BAR_DATA}
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={2}>
+            <StatsCard
+              title="TRANSACTIONS"
+              count={graphData.count}
+              badges={[
+                { label: "HITS", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "WRITES", value: graphData.indexCountTwo, variant: "warning" },
+                { label: "MISSES", value: graphData.indexCountThree, variant: "error" },
+              ]}
+              graph={
+                <CountGraph
+                  data={graphData.countFormattedData}
+                  barData={CACHE_BAR_DATA}
+                />
+              }
             />
-          }
-        />
-        <DurationCard
-          shortest={data.shortest}
-          longest={data.longest}
-          average={data.average}
-          p95={data.p95}
-          durationFormattedData={data.durationFormattedData}
-        />
-      </StatsGrid>
-      <CacheIndexTable />
-    </IndexLayout>
+            <DurationCard
+              shortest={graphData.shortest}
+              longest={graphData.longest}
+              average={graphData.average}
+              p95={graphData.p95}
+              durationFormattedData={graphData.durationFormattedData}
+            />
+          </StatsGrid>
+        )}
+        <CacheIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/cache/table/index.tsx
+++ b/packages/ui/src/screens/cache/table/index.tsx
@@ -3,7 +3,7 @@
 import { DatabaseZap } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { CacheInstanceResponse, CacheGroupResponse } from "@/hooks/useApiTyped";
 import { SearchInput } from "@/components/ui/search-input";
 import { TableLayout } from "@/components/ui/layout/table-layout";
@@ -27,10 +27,7 @@ export default function CacheIndexTable() {
     setInputValue,
     setInstanceStatusType,
     loadMore,
-  } = useTableData({
-    key: "cache",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "Transaction" : "Key";

--- a/packages/ui/src/screens/exception/index/index.tsx
+++ b/packages/ui/src/screens/exception/index/index.tsx
@@ -5,7 +5,7 @@ import ExceptionsIndexTable from "../table";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useExceptions } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const EXCEPTION_BAR_DATA = [
   { dataKey: "unhandledRejection", stackId: "a", fill: "#f1f5f9" },
@@ -13,29 +13,32 @@ const EXCEPTION_BAR_DATA = [
 ];
 
 export default function ExceptionsIndex() {
-  const { data } = useExceptions.useGraph({});
+  const tableData = useTableData({ key: "exceptions", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={1}>
-          <StatsCard
-            title="EXCEPTIONS"
-            count={data.count}
-            badges={[
-              { label: "UNHANDLED", value: data.indexCountOne, variant: "secondary" },
-              { label: "UNCAUGHT", value: data.indexCountTwo, variant: "warning" },
-            ]}
-            graph={
-              <CountGraph
-                data={data.countFormattedData}
-                barData={EXCEPTION_BAR_DATA}
-              />
-            }
-          />
-        </StatsGrid>
-      )}
-      <ExceptionsIndexTable />
-    </IndexLayout>
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={1}>
+            <StatsCard
+              title="EXCEPTIONS"
+              count={graphData.count}
+              badges={[
+                { label: "UNHANDLED", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "UNCAUGHT", value: graphData.indexCountTwo, variant: "warning" },
+              ]}
+              graph={
+                <CountGraph
+                  data={graphData.countFormattedData}
+                  barData={EXCEPTION_BAR_DATA}
+                />
+              }
+            />
+          </StatsGrid>
+        )}
+        <ExceptionsIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/exception/table/index.tsx
+++ b/packages/ui/src/screens/exception/table/index.tsx
@@ -4,7 +4,7 @@ import { Bug } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
 import { Input } from "@/components/ui/base/input";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { ExceptionGroupResponse, ExceptionInstanceResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -28,10 +28,7 @@ export default function ExceptionsIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData({
-    key: "exceptions",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const Table = index === "instance" ? InstanceTable : GroupTable;
   const count = index === "instance" ? instanceDataCount : groupDataCount;

--- a/packages/ui/src/screens/http/index/index.tsx
+++ b/packages/ui/src/screens/http/index/index.tsx
@@ -6,7 +6,7 @@ import HttpIndexTable from "../table";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useHttps } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const HTTP_BAR_DATA = [
   { dataKey: "count_200", name: "2XX", stackId: "a", fill: "#f1f5f9" },
@@ -15,37 +15,40 @@ const HTTP_BAR_DATA = [
 ];
 
 export default function HttpsIndex() {
-  const { data } = useHttps.useGraph();
+  const tableData = useTableData({ key: "https", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
-   return (
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={2}>
-          <StatsCard
-            title="REQUESTS"
-            count={data.count}
-            badges={[
-              { label: "1/2/3XX", value: data.indexCountOne, variant: "secondary" },
-              { label: "4XX", value: data.indexCountTwo, variant: "warning" },
-              { label: "5XX", value: data.indexCountThree, variant: "error" },
-            ]}
-            graph={
+  return (
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={2}>
+            <StatsCard
+              title="REQUESTS"
+              count={graphData.count}
+              badges={[
+                { label: "1/2/3XX", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "4XX", value: graphData.indexCountTwo, variant: "warning" },
+                { label: "5XX", value: graphData.indexCountThree, variant: "error" },
+              ]}
+              graph={
                 <CountGraph
-                  data={data.countFormattedData}
+                  data={graphData.countFormattedData}
                   barData={HTTP_BAR_DATA}
                 />
-            }
-          />
-          <DurationCard
-            shortest={data.shortest}
-            longest={data.longest}
-            average={data.average}
-            p95={data.p95}
-            durationFormattedData={data.durationFormattedData}
-          />
-        </StatsGrid>
-      )}
-      <HttpIndexTable />
-    </IndexLayout>
+              }
+            />
+            <DurationCard
+              shortest={graphData.shortest}
+              longest={graphData.longest}
+              average={graphData.average}
+              p95={graphData.p95}
+              durationFormattedData={graphData.durationFormattedData}
+            />
+          </StatsGrid>
+        )}
+        <HttpIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/http/table/index.tsx
+++ b/packages/ui/src/screens/http/table/index.tsx
@@ -3,7 +3,7 @@
 import { Globe } from "lucide-react";
 import { GroupTable } from "./group";
 import { InstanceTable } from "./instance";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { HttpClientGroupResponse, HttpClientInstanceResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -27,10 +27,7 @@ export default function HttpIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData<HttpClientInstanceResponse, HttpClientGroupResponse>({
-    key: "https",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "Request" : "Route";

--- a/packages/ui/src/screens/job/index/index.tsx
+++ b/packages/ui/src/screens/job/index/index.tsx
@@ -6,7 +6,7 @@ import JobsIndexTable from "../table";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useJobs } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const JOB_BAR_DATA = [
   { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
@@ -15,37 +15,40 @@ const JOB_BAR_DATA = [
 ];
 
 export default function JobsIndex() {
-  const { data } = useJobs.useGraph();
+  const tableData = useTableData({ key: "jobs", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={2}>
-          <StatsCard
-            title="JOB ATTEMPTS"
-            count={data.count}
-            badges={[
-              { label: "COMPLETED", value: data.indexCountOne, variant: "secondary" },
-              { label: "RELEASED", value: data.indexCountTwo, variant: "warning" },
-              { label: "FAILED", value: data.indexCountThree, variant: "error" },
-            ]}
-            graph={
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={2}>
+            <StatsCard
+              title="JOB ATTEMPTS"
+              count={graphData.count}
+              badges={[
+                { label: "COMPLETED", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "RELEASED", value: graphData.indexCountTwo, variant: "warning" },
+                { label: "FAILED", value: graphData.indexCountThree, variant: "error" },
+              ]}
+              graph={
                 <CountGraph
-                  data={data.countFormattedData}
+                  data={graphData.countFormattedData}
                   barData={JOB_BAR_DATA}
                 />
-            }
-          />
-          <DurationCard
-            shortest={data.shortest}
-            longest={data.longest}
-            average={data.average}
-            p95={data.p95}
-            durationFormattedData={data.durationFormattedData}
-          />
-        </StatsGrid>
-      )}
-      <JobsIndexTable />
-    </IndexLayout>
+              }
+            />
+            <DurationCard
+              shortest={graphData.shortest}
+              longest={graphData.longest}
+              average={graphData.average}
+              p95={graphData.p95}
+              durationFormattedData={graphData.durationFormattedData}
+            />
+          </StatsGrid>
+        )}
+        <JobsIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/job/table/index.tsx
+++ b/packages/ui/src/screens/job/table/index.tsx
@@ -4,7 +4,7 @@ import { Layers } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
 import { Input } from "@/components/ui/base/input";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { JobInstanceResponse, JobGroupResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -27,10 +27,7 @@ export default function JobsIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData({
-    key: "jobs",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "group" ? "Queue" : "ATTEMPT";

--- a/packages/ui/src/screens/log/index/index.tsx
+++ b/packages/ui/src/screens/log/index/index.tsx
@@ -5,7 +5,7 @@ import LogsIndexTable from "../table";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useLogs } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const LOG_LEVELS = [
   { dataKey: "info", variant: "secondary", fill: "#F3F7FA" },
@@ -18,38 +18,41 @@ const LOG_LEVELS = [
 ] as const;
 
 export default function LogsIndex() {
-  const { data } = useLogs.useGraph();
+  const tableData = useTableData({ key: "logs", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={1}>
-          <StatsCard
-            title="LOGS"
-            count={data.count}
-            badges={[
-              { label: "INFO", value: data.indexCountOne, variant: "secondary" },
-              { label: "WARN", value: data.indexCountTwo, variant: "warning" },
-              { label: "ERROR", value: data.indexCountThree, variant: "destructive" },
-              { label: "DEBUG", value: data.indexCountFive ?? 0, variant: "debug" },
-              { label: "TRACE", value: data.indexCountSix ?? 0, variant: "trace" },
-              { label: "FATAL", value: data.indexCountSeven ?? 0, variant: "error" },
-              { label: "LOG", value: data.indexCountEight ?? 0, variant: "log" },
-            ]}
-            graph={
-              <CountGraph
-                data={data.countFormattedData}
-                barData={LOG_LEVELS.map((level) => ({
-                  dataKey: level.dataKey,
-                  stackId: level.dataKey,
-                  fill: level.fill,
-                }))}
-              />
-            }
-          />
-        </StatsGrid>
-      )}
-      <LogsIndexTable />
-    </IndexLayout>
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={1}>
+            <StatsCard
+              title="LOGS"
+              count={graphData.count}
+              badges={[
+                { label: "INFO", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "WARN", value: graphData.indexCountTwo, variant: "warning" },
+                { label: "ERROR", value: graphData.indexCountThree, variant: "destructive" },
+                { label: "DEBUG", value: graphData.indexCountFive ?? 0, variant: "debug" },
+                { label: "TRACE", value: graphData.indexCountSix ?? 0, variant: "trace" },
+                { label: "FATAL", value: graphData.indexCountSeven ?? 0, variant: "error" },
+                { label: "LOG", value: graphData.indexCountEight ?? 0, variant: "log" },
+              ]}
+              graph={
+                <CountGraph
+                  data={graphData.countFormattedData}
+                  barData={LOG_LEVELS.map((level) => ({
+                    dataKey: level.dataKey,
+                    stackId: level.dataKey,
+                    fill: level.fill,
+                  }))}
+                />
+              }
+            />
+          </StatsGrid>
+        )}
+        <LogsIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/log/table/index.tsx
+++ b/packages/ui/src/screens/log/table/index.tsx
@@ -3,7 +3,7 @@
 import { Logs } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { Input } from "@/components/ui/base/input";
 import { LogInstanceResponse, LogGroupResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
@@ -23,10 +23,7 @@ export default function LogsIndexTable() {
     message,
     setInputValue,
     loadMore,
-  } = useTableData<LogInstanceResponse, LogGroupResponse>({
-    key: "logs",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "Log" : "Source";

--- a/packages/ui/src/screens/mail/index/index.tsx
+++ b/packages/ui/src/screens/mail/index/index.tsx
@@ -6,7 +6,7 @@ import MailsIndexTable from "../table";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useMails } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const MAIL_BAR_DATA = [
   { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
@@ -14,36 +14,39 @@ const MAIL_BAR_DATA = [
 ];
 
 export default function MailsIndex() {
-  const { data } = useMails.useGraph();
+  const tableData = useTableData({ key: "mails", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
-    return(
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={2}>
-          <StatsCard
-            title="MAILS"
-            count={data.count}
-            badges={[
-              { label: "COMPLETED", value: data.indexCountOne, variant: "secondary" },
-              { label: "FAILED", value: data.indexCountTwo, variant: "error" },
-            ]}
-            graph={
-              <CountGraph
-                data={data.countFormattedData}
-                barData={MAIL_BAR_DATA}
-              />
-            }
-          />
-          <DurationCard
-            shortest={data.shortest}
-            longest={data.longest}
-            average={data.average}
-            p95={data.p95}
-            durationFormattedData={data.durationFormattedData}
-          />
-        </StatsGrid>
-      )}
-      <MailsIndexTable />
-    </IndexLayout>
+  return (
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={2}>
+            <StatsCard
+              title="MAILS"
+              count={graphData.count}
+              badges={[
+                { label: "COMPLETED", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "FAILED", value: graphData.indexCountTwo, variant: "error" },
+              ]}
+              graph={
+                <CountGraph
+                  data={graphData.countFormattedData}
+                  barData={MAIL_BAR_DATA}
+                />
+              }
+            />
+            <DurationCard
+              shortest={graphData.shortest}
+              longest={graphData.longest}
+              average={graphData.average}
+              p95={graphData.p95}
+              durationFormattedData={graphData.durationFormattedData}
+            />
+          </StatsGrid>
+        )}
+        <MailsIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/mail/table/index.tsx
+++ b/packages/ui/src/screens/mail/table/index.tsx
@@ -3,7 +3,7 @@
 import { Mail } from "lucide-react";
 import { GroupTable } from "./group";
 import { InstanceTable } from "./instance";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { Input } from "@/components/ui/base/input";
 import { MailInstanceResponse, MailGroupResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
@@ -28,10 +28,7 @@ export default function MailsIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData<MailInstanceResponse, MailGroupResponse>({
-    key: "mails",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "Mail" : "Receiver";

--- a/packages/ui/src/screens/model/index/index.tsx
+++ b/packages/ui/src/screens/model/index/index.tsx
@@ -6,7 +6,7 @@ import ModelIndexTable from "../table/index";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useModels } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const MODEL_BAR_DATA = [
   { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
@@ -14,36 +14,39 @@ const MODEL_BAR_DATA = [
 ];
 
 export default function ModelIndex() {
-  const { data } = useModels.useGraph();
+  const tableData = useTableData({ key: "models", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={2}>
-          <StatsCard
-            title="INSTANCES"
-            count={data.count}
-            badges={[
-              { label: "COMPLETED", value: data.indexCountOne, variant: "secondary" },
-              { label: "FAILED", value: data.indexCountTwo, variant: "destructive" },
-            ]}
-            graph={
-              <CountGraph
-                data={data.countFormattedData}
-                barData={MODEL_BAR_DATA}
-              />
-            }
-          />
-          <DurationCard
-            shortest={data.shortest}
-            longest={data.longest}
-            average={data.average}
-            p95={data.p95}
-            durationFormattedData={data.durationFormattedData}
-          />
-        </StatsGrid>
-      )}
-      <ModelIndexTable />
-    </IndexLayout>
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={2}>
+            <StatsCard
+              title="INSTANCES"
+              count={graphData.count}
+              badges={[
+                { label: "COMPLETED", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "FAILED", value: graphData.indexCountTwo, variant: "destructive" },
+              ]}
+              graph={
+                <CountGraph
+                  data={graphData.countFormattedData}
+                  barData={MODEL_BAR_DATA}
+                />
+              }
+            />
+            <DurationCard
+              shortest={graphData.shortest}
+              longest={graphData.longest}
+              average={graphData.average}
+              p95={graphData.p95}
+              durationFormattedData={graphData.durationFormattedData}
+            />
+          </StatsGrid>
+        )}
+        <ModelIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/model/table/index.tsx
+++ b/packages/ui/src/screens/model/table/index.tsx
@@ -4,7 +4,7 @@ import { Cuboid } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
 import { Input } from "@/components/ui/base/input";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { ModelInstanceResponse, ModelGroupResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -28,10 +28,7 @@ export default function ModelsIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData<ModelInstanceResponse, ModelGroupResponse>({
-    key: "models",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "Instance" : "Model";

--- a/packages/ui/src/screens/notification/index/index.tsx
+++ b/packages/ui/src/screens/notification/index/index.tsx
@@ -6,9 +6,7 @@ import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
 import NotificationsIndexTable from "../table";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
-import { useNotifications } from "@/hooks/useApiTyped";
-import { StoreContext } from "@/store";
-import { useContext } from "react";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const NOTIFICATION_BAR_DATA = [
   { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
@@ -16,37 +14,39 @@ const NOTIFICATION_BAR_DATA = [
 ];
 
 export default function NotificationsIndex() {
-  const { state } = useContext(StoreContext);
-  const { data } = useNotifications.useGraph();
+  const tableData = useTableData({ key: "notifications", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={2}>
-          <StatsCard
-            title="NOTIFICATIONS"
-            count={data.count}
-            badges={[
-              { label: "Completed", value: data.indexCountOne, variant: "secondary" },
-              { label: "Failed", value: data.indexCountTwo, variant: "error" },
-            ]}
-            graph={
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={2}>
+            <StatsCard
+              title="NOTIFICATIONS"
+              count={graphData.count}
+              badges={[
+                { label: "Completed", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "Failed", value: graphData.indexCountTwo, variant: "error" },
+              ]}
+              graph={
                 <CountGraph
-                  data={data.countFormattedData}
+                  data={graphData.countFormattedData}
                   barData={NOTIFICATION_BAR_DATA}
                 />
-            }
-          />
-          <DurationCard
-            shortest={data.shortest}
-            longest={data.longest}
-            average={data.average}
-            p95={data.p95}
-            durationFormattedData={data.durationFormattedData}
-           />
-        </StatsGrid>
-      )}
-      <NotificationsIndexTable />
-    </IndexLayout>
+              }
+            />
+            <DurationCard
+              shortest={graphData.shortest}
+              longest={graphData.longest}
+              average={graphData.average}
+              p95={graphData.p95}
+              durationFormattedData={graphData.durationFormattedData}
+            />
+          </StatsGrid>
+        )}
+        <NotificationsIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/notification/table/index.tsx
+++ b/packages/ui/src/screens/notification/table/index.tsx
@@ -4,7 +4,7 @@ import { MessageSquareDot } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
 import { Input } from "@/components/ui/base/input";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { NotificationInstanceResponse, NotificationGroupResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -28,10 +28,7 @@ export default function NotificationsIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData<NotificationInstanceResponse, NotificationGroupResponse>({
-    key: "notifications",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "group" ? groupDataCount : instanceDataCount;
   const label = index === "group" ? "Channel" : "Notification";

--- a/packages/ui/src/screens/query/index/index.tsx
+++ b/packages/ui/src/screens/query/index/index.tsx
@@ -6,8 +6,7 @@ import QueryIndexTable from "../table";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { IndexLayout } from "@/components/ui/layout/index-layout";
 import { StatsGrid } from "@/components/ui/stats-grid";
-import { useQueries } from "@/hooks/useApiTyped";
-import { useSearchParams } from "react-router";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 const QUERY_BAR_DATA = [
   { dataKey: "COMPLETED", stackId: "a", fill: document.documentElement.classList.contains("dark")
@@ -17,48 +16,39 @@ const QUERY_BAR_DATA = [
 ];
 
 export default function QueryIndex() {
-  const [searchParams] = useSearchParams();
-
-  const period = searchParams.get("period") as any;
-  const status = searchParams.get("status") || undefined;
-  const q = searchParams.get("q") || undefined;
-  const key = searchParams.get("key") || undefined;
-
-  const { data } = useQueries.useGraph({
-    period,
-    status,
-    q,
-    key,
-  });
+  const tableData = useTableData({ key: "queries", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <IndexLayout>
-      {data && (
-        <StatsGrid columns={2}>
-          <StatsCard
-            title="QUERIES"
-            count={data.count}
-            badges={[
-              { label: "COMPLETED", value: data.indexCountOne, variant: "secondary" },
-              { label: "FAILED", value: data.indexCountTwo, variant: "destructive" },
-            ]}
-            graph={
-              <CountGraph
-                data={data.countFormattedData}
-                barData={QUERY_BAR_DATA}
-              />
-            }
-          />
-          <DurationCard
-            shortest={data.shortest}
-            longest={data.longest}
-            average={data.average}
-            p95={data.p95}
-            durationFormattedData={data.durationFormattedData}
-          />
-        </StatsGrid>
-      )}
-      <QueryIndexTable />
-    </IndexLayout>
+    <TableDataContext.Provider value={tableData}>
+      <IndexLayout>
+        {graphData && (
+          <StatsGrid columns={2}>
+            <StatsCard
+              title="QUERIES"
+              count={graphData.count}
+              badges={[
+                { label: "COMPLETED", value: graphData.indexCountOne, variant: "secondary" },
+                { label: "FAILED", value: graphData.indexCountTwo, variant: "destructive" },
+              ]}
+              graph={
+                <CountGraph
+                  data={graphData.countFormattedData}
+                  barData={QUERY_BAR_DATA}
+                />
+              }
+            />
+            <DurationCard
+              shortest={graphData.shortest}
+              longest={graphData.longest}
+              average={graphData.average}
+              p95={graphData.p95}
+              durationFormattedData={graphData.durationFormattedData}
+            />
+          </StatsGrid>
+        )}
+        <QueryIndexTable />
+      </IndexLayout>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/query/table/index.tsx
+++ b/packages/ui/src/screens/query/table/index.tsx
@@ -4,7 +4,7 @@ import { Database } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
 import { Input } from "@/components/ui/base/input";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { QueryGroupResponse, QueryInstanceResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -28,10 +28,7 @@ export default function QueryIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData<QueryInstanceResponse, QueryGroupResponse>({
-    key: "queries",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "Query" : "Endpoint";

--- a/packages/ui/src/screens/request/index/index.tsx
+++ b/packages/ui/src/screens/request/index/index.tsx
@@ -10,111 +10,101 @@ import {
   CardSubtitle,
 } from "@/components/ui/base/card";
 import { Badge } from "@/components/ui/base/badge";
-import { useRequests } from "@/hooks/useApiTyped";
-import { useSearchParams } from "react-router";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 export default function RequestsIndex() {
-  const [searchParams] = useSearchParams();
-
-  const period = searchParams.get("period") as any;
-  const status = searchParams.get("status") || undefined;
-  const q = searchParams.get("q") || undefined;
-  const key = searchParams.get("key") || undefined;
-
-  const { data, isLoading } = useRequests.useGraph({
-    period,
-    status,
-    q,
-    key,
-  });
-
-  if (isLoading || !data) return null;
+  const tableData = useTableData({ key: "requests", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <div className="flex flex-col gap-6 w-full">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <div>
-              <CardTitle className="text-sm font-medium text-muted-foreground">
-                REQUESTS
-              </CardTitle>
-              <CardSubtitle>{data.count}</CardSubtitle>
-            </div>
-            <div className="flex gap-4 text-xs">
-              <div className="flex flex-col items-center">
-                <span className="text-muted-foreground">1/2/3XX</span>
-                <Badge variant="secondary" className="mt-1">
-                  {data.indexCountOne}
-                </Badge>
-              </div>
-              <div className="flex flex-col items-center text-yellow-600">
-                <span className="text-muted-foreground">4XX</span>
-                <Badge variant="warning" className="mt-1">
-                  {data.indexCountTwo}
-                </Badge>
-              </div>
-              <div className="flex flex-col items-center text-red-500">
-                <span className="text-muted-foreground">5XX</span>
-                <Badge variant="destructive" className="mt-1">
-                  {data.indexCountThree}
-                </Badge>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="h-auto">
-              <CountGraph
-                data={data.countFormattedData}
-                barData={[
-                  {
-                    dataKey: "count_200",
-                    name: "1/2/3XX",
-                    stackId: "a",
-                    fill: document.documentElement.classList.contains("dark")
-                      ? "#242427"
-                      : "#f1f5f9",
-                  },
-                  { dataKey: "count_400", name: "4XX", stackId: "b", fill: "#ffc658" },
-                  { dataKey: "count_500", name: "5XX", stackId: "c", fill: "#ef4444" },
-                ]}
-              />
-            </div>
-          </CardContent>
-        </Card>
+    <TableDataContext.Provider value={tableData}>
+      <div className="flex flex-col gap-6 w-full">
+        {graphData && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <div>
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
+                    REQUESTS
+                  </CardTitle>
+                  <CardSubtitle>{graphData.count}</CardSubtitle>
+                </div>
+                <div className="flex gap-4 text-xs">
+                  <div className="flex flex-col items-center">
+                    <span className="text-muted-foreground">1/2/3XX</span>
+                    <Badge variant="secondary" className="mt-1">
+                      {graphData.indexCountOne}
+                    </Badge>
+                  </div>
+                  <div className="flex flex-col items-center text-yellow-600">
+                    <span className="text-muted-foreground">4XX</span>
+                    <Badge variant="warning" className="mt-1">
+                      {graphData.indexCountTwo}
+                    </Badge>
+                  </div>
+                  <div className="flex flex-col items-center text-red-500">
+                    <span className="text-muted-foreground">5XX</span>
+                    <Badge variant="destructive" className="mt-1">
+                      {graphData.indexCountThree}
+                    </Badge>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="h-auto">
+                  <CountGraph
+                    data={graphData.countFormattedData}
+                    barData={[
+                      {
+                        dataKey: "count_200",
+                        name: "1/2/3XX",
+                        stackId: "a",
+                        fill: document.documentElement.classList.contains("dark")
+                          ? "#242427"
+                          : "#f1f5f9",
+                      },
+                      { dataKey: "count_400", name: "4XX", stackId: "b", fill: "#ffc658" },
+                      { dataKey: "count_500", name: "5XX", stackId: "c", fill: "#ef4444" },
+                    ]}
+                  />
+                </div>
+              </CardContent>
+            </Card>
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <div>
-              <CardTitle className="text-sm font-medium text-muted-foreground">
-                DURATION
-              </CardTitle>
-              <CardSubtitle>
-                {data.shortest} – {data.longest}
-              </CardSubtitle>
-            </div>
-            <div className="flex items-center gap-4 text-xs">
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">AVG</span>
-                <Badge variant="secondary">{data.average}</Badge>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">P95</span>
-                <Badge variant="warning">{data.p95}</Badge>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="h-auto">
-              <DurationGraph data={data.durationFormattedData} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <div>
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
+                    DURATION
+                  </CardTitle>
+                  <CardSubtitle>
+                    {graphData.shortest} – {graphData.longest}
+                  </CardSubtitle>
+                </div>
+                <div className="flex items-center gap-4 text-xs">
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted-foreground">AVG</span>
+                    <Badge variant="secondary">{graphData.average}</Badge>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted-foreground">P95</span>
+                    <Badge variant="warning">{graphData.p95}</Badge>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="h-auto">
+                  <DurationGraph data={graphData.durationFormattedData} />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
 
-      <div className="flex flex-col gap-4">
-        <RequestIndexTable />
+        <div className="flex flex-col gap-4">
+          <RequestIndexTable />
+        </div>
       </div>
-    </div>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/request/table/index.tsx
+++ b/packages/ui/src/screens/request/table/index.tsx
@@ -6,7 +6,7 @@ import { GroupTable } from "./group";
 import { Input } from "@/components/ui/base/input";
 import { Button } from "@/components/ui/base/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/base/toggle-group";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { RequestGroupResponse, RequestInstanceResponse } from "@/hooks/useApiTyped";
 import { SearchInput } from "@/components/ui/search-input";
@@ -25,10 +25,7 @@ export default function RequestIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData({
-    key: "requests",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const loadMoreButton = (
     <div className="flex justify-center my-2">

--- a/packages/ui/src/screens/schedule/index/index.tsx
+++ b/packages/ui/src/screens/schedule/index/index.tsx
@@ -4,93 +4,96 @@ import {
   Card,
   CardContent,
   CardHeader,
-  CardTitle,
   CardSubtitle,
+  CardTitle,
 } from "@/components/ui/base/card";
 import { Badge } from "@/components/ui/base/badge";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import SchedulesIndexTable from "../table";
 import { DurationGraph } from "@/components/ui/graphs/duration-graph";
-import { useSchedules } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 export default function SchedulesIndex() {
-  const { data } = useSchedules.useGraph();
+  const tableData = useTableData({ key: "schedules", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <div className="flex flex-col gap-6">
-      {data &&
-        <div className="grid grid-cols-2 gap-4">
-          <Card>
-            <CardHeader className="pb-2">
-              <div className="flex justify-between items-center">
-                <div>
-                  <CardTitle className="text-sm text-muted-foreground">
-                    RUNS
-                  </CardTitle>
-                  <CardSubtitle>{data.count}</CardSubtitle>
-                </div>
-                <div className="flex gap-4 text-xs">
-                  <div className="flex flex-col items-center">
-                    <span className="text-muted-foreground">COMPLETED</span>
-                    <Badge variant="secondary" className="mt-1">
-                      {data.indexCountOne}
-                    </Badge>
-                  </div>
-                  <div className="flex flex-col items-center">
-                    <span className="text-muted-foreground">FAILED</span>
-                    <Badge variant="error" className="mt-1">
-                      {data.indexCountTwo}
-                    </Badge>
-                  </div>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-auto">
-                <CountGraph
-                  data={data.countFormattedData}
-                  barData={[
-                    { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
-                    { dataKey: "failed", stackId: "c", fill: "#ef4444" },
-                  ]}
-                />
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <div className="flex justify-between items-center">
-                <div>
-                  <CardTitle className="text-sm text-muted-foreground">
-                    DURATION
-                  </CardTitle>
-                  <CardSubtitle>
-                    {data.shortest} – {data.longest}
-                  </CardSubtitle>
-                </div>
-                <div className="flex gap-4 text-xs">
+    <TableDataContext.Provider value={tableData}>
+      <div className="flex flex-col gap-6">
+        {graphData && (
+          <div className="grid grid-cols-2 gap-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <div className="flex justify-between items-center">
                   <div>
-                    <span className="text-muted-foreground mr-1">AVG</span>
-                    <Badge variant="secondary">{data.average}</Badge>
+                    <CardTitle className="text-sm text-muted-foreground">
+                      RUNS
+                    </CardTitle>
+                    <CardSubtitle>{graphData.count}</CardSubtitle>
                   </div>
-                  <div>
-                    <span className="text-muted-foreground mr-1">P95</span>
-                    <Badge variant="warning">{data.p95}</Badge>
+                  <div className="flex gap-4 text-xs">
+                    <div className="flex flex-col items-center">
+                      <span className="text-muted-foreground">COMPLETED</span>
+                      <Badge variant="secondary" className="mt-1">
+                        {graphData.indexCountOne}
+                      </Badge>
+                    </div>
+                    <div className="flex flex-col items-center">
+                      <span className="text-muted-foreground">FAILED</span>
+                      <Badge variant="error" className="mt-1">
+                        {graphData.indexCountTwo}
+                      </Badge>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-auto">
-                <DurationGraph data={data.durationFormattedData} />
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      }
+              </CardHeader>
+              <CardContent>
+                <div className="h-auto">
+                  <CountGraph
+                    data={graphData.countFormattedData}
+                    barData={[
+                      { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
+                      { dataKey: "failed", stackId: "c", fill: "#ef4444" },
+                    ]}
+                  />
+                </div>
+              </CardContent>
+            </Card>
 
-      <SchedulesIndexTable />
-    </div>
+            <Card>
+              <CardHeader className="pb-2">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <CardTitle className="text-sm text-muted-foreground">
+                      DURATION
+                    </CardTitle>
+                    <CardSubtitle>
+                      {graphData.shortest} – {graphData.longest}
+                    </CardSubtitle>
+                  </div>
+                  <div className="flex gap-4 text-xs">
+                    <div>
+                      <span className="text-muted-foreground mr-1">AVG</span>
+                      <Badge variant="secondary">{graphData.average}</Badge>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground mr-1">P95</span>
+                      <Badge variant="warning">{graphData.p95}</Badge>
+                    </div>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="h-auto">
+                  <DurationGraph data={graphData.durationFormattedData} />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        <SchedulesIndexTable />
+      </div>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/schedule/table/index.tsx
+++ b/packages/ui/src/screens/schedule/table/index.tsx
@@ -3,7 +3,7 @@
 import { CalendarCheck } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { ScheduleInstanceResponse, ScheduleGroupResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -24,10 +24,7 @@ export default function ScheduledIndexTable() {
     message,
     setInstanceStatusType,
     loadMore,
-  } = useTableData<ScheduleInstanceResponse, ScheduleGroupResponse>({
-    key: "schedules",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "Attempt" : "Schedule";

--- a/packages/ui/src/screens/view/index/index.tsx
+++ b/packages/ui/src/screens/view/index/index.tsx
@@ -10,86 +10,89 @@ import { Badge } from "@/components/ui/base/badge";
 import ViewsIndexTable from "../table/index";
 import { CountGraph } from "@/components/ui/graphs/count-graph";
 import { DurationGraph } from "@/components/ui/graphs/duration-graph";
-import { useViews } from "@/hooks/useApiTyped";
+import { useTableData, TableDataContext } from "@/hooks/useTableData";
 
 export default function ViewsIndex() {
-  const { data } = useViews.useGraph();
+  const tableData = useTableData({ key: "views", defaultInstanceStatusType: "all" });
+  const { graphData } = tableData;
 
   return (
-    <div className="flex flex-col gap-6">
-      {data &&
-      <div className="grid grid-cols-2 gap-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <div className="flex justify-between items-center">
-              <div>
-                <CardTitle className="text-sm text-muted-foreground">
-                  VIEWS
-                </CardTitle>
-                <CardSubtitle>{data.count}</CardSubtitle>
-              </div>
-            </div>
-            <div className="flex gap-4 text-xs">
-              <div className="flex flex-col items-center">
-                <span className="text-muted-foreground">COMPLETED</span>
-                <Badge variant="secondary" className="mt-1">
-                  {data.indexCountOne}
-                </Badge>
-              </div>
-              <div className="flex flex-col items-center text-red-500">
-                <span className="text-muted-foreground">FAILED</span>
-                <Badge variant="destructive" className="mt-1">
-                  {data.indexCountTwo}
-                </Badge>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="h-auto">
-              <CountGraph
-                data={data.countFormattedData}
-                barData={[
-                  { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
-                  { dataKey: "failed", stackId: "b", fill: "#ef4444" },
-                ]}
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <div className="flex justify-between items-center">
-              <div>
-                <CardTitle className="text-sm text-muted-foreground">
-                  DURATION
-                </CardTitle>
-                <CardSubtitle>
-                  {data.shortest} – {data.longest}
-                </CardSubtitle>
-              </div>
-              <div className="flex gap-4 text-xs">
-                <div>
-                  <span className="text-muted-foreground mr-1">AVG</span>
-                  <Badge variant="secondary">{data.average}</Badge>
+    <TableDataContext.Provider value={tableData}>
+      <div className="flex flex-col gap-6">
+        {graphData && (
+          <div className="grid grid-cols-2 gap-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <CardTitle className="text-sm text-muted-foreground">
+                      VIEWS
+                    </CardTitle>
+                    <CardSubtitle>{graphData.count}</CardSubtitle>
+                  </div>
                 </div>
-                <div>
-                  <span className="text-muted-foreground mr-1">P95</span>
-                  <Badge variant="warning">{data.p95}</Badge>
+                <div className="flex gap-4 text-xs">
+                  <div className="flex flex-col items-center">
+                    <span className="text-muted-foreground">COMPLETED</span>
+                    <Badge variant="secondary" className="mt-1">
+                      {graphData.indexCountOne}
+                    </Badge>
+                  </div>
+                  <div className="flex flex-col items-center text-red-500">
+                    <span className="text-muted-foreground">FAILED</span>
+                    <Badge variant="destructive" className="mt-1">
+                      {graphData.indexCountTwo}
+                    </Badge>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="h-auto">
-              <DurationGraph data={data.durationFormattedData} />
-            </div>
-          </CardContent>
-        </Card>
-        </div>
-      }
+              </CardHeader>
+              <CardContent>
+                <div className="h-auto">
+                  <CountGraph
+                    data={graphData.countFormattedData}
+                    barData={[
+                      { dataKey: "completed", stackId: "a", fill: "#f1f5f9" },
+                      { dataKey: "failed", stackId: "b", fill: "#ef4444" },
+                    ]}
+                  />
+                </div>
+              </CardContent>
+            </Card>
 
-      <ViewsIndexTable />
-    </div>
+            <Card>
+              <CardHeader className="pb-2">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <CardTitle className="text-sm text-muted-foreground">
+                      DURATION
+                    </CardTitle>
+                    <CardSubtitle>
+                      {graphData.shortest} – {graphData.longest}
+                    </CardSubtitle>
+                  </div>
+                  <div className="flex gap-4 text-xs">
+                    <div>
+                      <span className="text-muted-foreground mr-1">AVG</span>
+                      <Badge variant="secondary">{graphData.average}</Badge>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground mr-1">P95</span>
+                      <Badge variant="warning">{graphData.p95}</Badge>
+                    </div>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="h-auto">
+                  <DurationGraph data={graphData.durationFormattedData} />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        <ViewsIndexTable />
+      </div>
+    </TableDataContext.Provider>
   );
 }

--- a/packages/ui/src/screens/view/table/index.tsx
+++ b/packages/ui/src/screens/view/table/index.tsx
@@ -4,7 +4,7 @@ import { FileCode } from "lucide-react";
 import { InstanceTable } from "./instance";
 import { GroupTable } from "./group";
 import { Input } from "@/components/ui/base/input";
-import { useTableData } from "@/hooks/useTableData";
+import { useTableDataContext } from "@/hooks/useTableData";
 import { ViewInstanceResponse, ViewGroupResponse } from "@/hooks/useApiTyped";
 import { TableLayout } from "@/components/ui/layout/table-layout";
 import { LoadMoreButton } from "@/components/ui/load-more-button";
@@ -28,10 +28,7 @@ export default function ViewsIndexTable() {
     setInstanceStatusType,
     setInputValue,
     loadMore,
-  } = useTableData<ViewInstanceResponse, ViewGroupResponse>({
-    key: "views",
-    defaultInstanceStatusType: "all",
-  });
+  } = useTableDataContext();
 
   const count = index === "instance" ? instanceDataCount : groupDataCount;
   const label = index === "instance" ? "View" : "Path";


### PR DESCRIPTION
## Summary

- Extends `useTableData` to fetch graph data internally using the same filter state (q, status, key) it already manages — exposing `graphData` and `graphLoading` in its return value
- Introduces `TableDataContext` and `useTableDataContext()` so graph and table state share a single hook instance per screen
- Screen index files now call `useTableData` once, wrap children in `<TableDataContext.Provider>`, and read `graphData` from it — removing all separate `useGraph` calls
- All 12 table components switch from `useTableData({...})` to `useTableDataContext()` to consume the shared state

## Test plan

- [ ] Navigate to each screen (requests, queries, cache, exceptions, jobs, schedules, http, logs, mail, model, notifications, views) and verify graphs render correctly
- [ ] Apply a search filter (q) and verify both graph and table update together
- [ ] Apply a status filter and verify both graph and table update together
- [ ] Drill into a group row (sets modelKey/key) and verify graph reflects the filtered data
- [ ] Change the period and verify graph and table both refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)